### PR TITLE
Updates CheckoutEngine for better checkout duration handling:

### DIFF
--- a/src/library-server/src/main/resources/application-dev.properties
+++ b/src/library-server/src/main/resources/application-dev.properties
@@ -17,3 +17,6 @@ logging.level.root=INFO
 ### Show Hibernate SQL queries when run.
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+## Library System Properties
+library.checkout.duration=24h


### PR DESCRIPTION
- Duration now stored as Java Duration object instead of as a long.
- Duration is loaded as a value from Spring Configuration with a default of 2 weeks.
- Added duration to Dev Properties file of 24 hours (as an example).
- Duration is logged in debug logging.